### PR TITLE
Add link to additional settings from skill-mark-2 (idle screen selection, etc)

### DIFF
--- a/containments/mark2/package/contents/ui/panel/contents/ui/quicksettings/AdditionalSettingsDelegate.qml
+++ b/containments/mark2/package/contents/ui/panel/contents/ui/quicksettings/AdditionalSettingsDelegate.qml
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 by Aditya Mehra <aix.m@outlook.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import QtQuick 2.1
+import QtQuick.Layouts 1.1
+import org.kde.kirigami 2.5 as Kirigami
+import Mycroft 1.0 as Mycroft
+import Mycroft.Private.Mark2SystemAccess 1.0
+
+Delegate {
+    iconSource: "settings-configure"
+    text: i18n("Additional Settings")
+    onClicked: {
+        Mycroft.MycroftController.sendRequest("mycroft.device.settings", {})
+    }
+}
+
+ 

--- a/containments/mark2/package/contents/ui/panel/contents/ui/quicksettings/QuickSettings.qml
+++ b/containments/mark2/package/contents/ui/panel/contents/ui/quicksettings/QuickSettings.qml
@@ -57,6 +57,7 @@ ColumnLayout {
         HomeDelegate {}
         WirelessDelegate {}
         MuteDelegate {}
+        AdditionalSettingsDelegate {}
         RebootDelegate {}
         ShutdownDelegate {}
     }


### PR DESCRIPTION
Add delegate link to skill-mark-2 device settings which handles: homescreen/idle screen selection and more