### PR TITLE
Rotate screen 180 degrees for new SJ201

### DIFF
--- a/lookandfeel/contents/plasmoidsetupscripts/org.kde.mycroft.mark2.js
+++ b/lookandfeel/contents/plasmoidsetupscripts/org.kde.mycroft.mark2.js
@@ -1,5 +1,5 @@
 applet.wallpaperPlugin = 'org.kde.color'
-applet.writeConfig("rotation", "CW")
+applet.writeConfig("rotation", "CCW")
 applet.currentConfigGroup = ["Wallpaper", "org.kde.color", "General"]
 applet.writeConfig("Color", "0,0,0")
 applet.reloadConfig()


### PR DESCRIPTION
With the new SJ201 Mark II hardware design, the screen got rotated another 180 degrees to make the dsi cable connection simpler. The new orientation will still be landscape, just upside down to the previous build.