### PR TITLE
Add basic cpack configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 PROJECT(mycroft-gui-mark-2)
+set(PROJECT_VERSION 1.0.3)
 
 # Set minimum CMake version (required for CMake 3.0 or later)
 cmake_minimum_required(VERSION 2.8.12)
@@ -43,3 +44,10 @@ plasma_install_package(lookandfeel org.mycroft.mark2 look-and-feel lookandfeel)
 add_subdirectory(containments)
 
 
+set(CPACK_GENERATOR "DEB")
+set(CPACK_DEBIAN_PACKAGE_NAME "${CMAKE_PROJECT_NAME}")
+set(CPACK_DEBIAN_PACKAGE_VERSION ${PROJECT_VERSION})
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Mycroft AI")
+set(CPACK_DEBIAN_FILE_NAME "${CMAKE_PROJECT_NAME}_${PROJECT_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb")
+
+INCLUDE(CPack)


### PR DESCRIPTION
#### Description
Adds cpack configuration variables to ensure consistency in packaging. 

Currently the version number is hard coded. I bumped the patch version. I'm sure there's a better way to do this. I'm thinking we should be tagging releases on Github and pull the version from that tag.

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
On an existing Mark II
```bash
sudo apt install qtdeclarative5-dev plasma-workspace-dev gettext
git clone https://github.com/MycroftAI/mycroft-gui-mark-2
mkdir mycroft-gui-mark-2/build && cd mycroft-gui-mark-2/build
cmake ..
cmake --build .
cpack
```