### PR TITLE
make sure panel position is 0 when closed

### DIFF
--- a/containments/mark2/package/contents/ui/panel/SlidingPanel.qml
+++ b/containments/mark2/package/contents/ui/panel/SlidingPanel.qml
@@ -30,7 +30,7 @@ PlasmaCore.ColorScope {
 
     readonly property bool horizontal: width > height
 
-    readonly property real position: 1 - (flickable.contentY - contentHeight + height) / height
+    readonly property real position: state == "closed" ? 0 : 1 - (flickable.contentY - contentHeight + height) / height
 
     readonly property real contentHeight: quickSettings.height + layout.anchors.margins * 2
     state: "closed"


### PR DESCRIPTION
- Possible fix for panel steeling events on boot, panel position should always be 0 when closed.